### PR TITLE
fix: turbopack file trace root issue fix

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
+  outputFileTracingRoot: path.resolve(__dirname),
   /* config options here */
+  
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request makes a small update to the Next.js configuration by setting the `outputFileTracingRoot` property using the absolute path to the project root. This change helps ensure that output file tracing works correctly when deploying or building the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration to improve server build tracing.
  * Enhances consistency of builds across environments and deployment targets.
  * No changes to user interface or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->